### PR TITLE
Bugfix: Add override val for `$nav-width`

### DIFF
--- a/app/assets/stylesheets/uswds_rails_overrides/all.scss
+++ b/app/assets/stylesheets/uswds_rails_overrides/all.scss
@@ -1,6 +1,7 @@
 // Core -------------- //
 
 @import 'core/fonts';
+@import 'core/defaults';
 
 // Elements -------------- //
 

--- a/app/assets/stylesheets/uswds_rails_overrides/core/_defaults.scss
+++ b/app/assets/stylesheets/uswds_rails_overrides/core/_defaults.scss
@@ -1,0 +1,1 @@
+$nav-width:  951px !default;


### PR DESCRIPTION
- Used in override file app/assets/stylesheets/uswds_rails_overrides/components/_header.scss
- When used without defining, shows up as Undefined variable: "$nav-width".
- Confirmed locally that this fixes the issue
